### PR TITLE
Constant names should comply with a naming convention

### DIFF
--- a/src/main/java/org/elasticsearch/analysis/STConvertIndicesAnalysis.java
+++ b/src/main/java/org/elasticsearch/analysis/STConvertIndicesAnalysis.java
@@ -64,7 +64,7 @@ public class STConvertIndicesAnalysis extends AbstractComponent {
 
                     @Override
                     public Tokenizer create() {
-                        return new STConvertTokenizer(STConvertType.simple2traditional,",",false);
+                        return new STConvertTokenizer(STConvertType.SIMPLE_2_TRADITIONAL,",",false);
                     }
                 }));
 
@@ -77,7 +77,7 @@ public class STConvertIndicesAnalysis extends AbstractComponent {
 
                     @Override
                     public Tokenizer create() {
-                        return new STConvertTokenizer(STConvertType.traditional2simple,",",false);
+                        return new STConvertTokenizer(STConvertType.TRADITIONAL_2_SIMPLE,",",false);
                     }
                 }));
         indicesAnalysisService.tokenizerFactories().put("stconvert_keep_both",
@@ -89,7 +89,7 @@ public class STConvertIndicesAnalysis extends AbstractComponent {
 
                     @Override
                     public Tokenizer create() {
-                        return new STConvertTokenizer(STConvertType.simple2traditional,",",true);
+                        return new STConvertTokenizer(STConvertType.SIMPLE_2_TRADITIONAL,",",true);
                     }
                 }));
         indicesAnalysisService.tokenizerFactories().put("tsconvert_keep_both",
@@ -101,7 +101,7 @@ public class STConvertIndicesAnalysis extends AbstractComponent {
 
                     @Override
                     public Tokenizer create() {
-                        return new STConvertTokenizer(STConvertType.traditional2simple,",",true);
+                        return new STConvertTokenizer(STConvertType.TRADITIONAL_2_SIMPLE,",",true);
                     }
                 }));
 
@@ -117,7 +117,7 @@ public class STConvertIndicesAnalysis extends AbstractComponent {
 
                     @Override
                     public TokenStream create(TokenStream tokenStream) {
-                        return new STConvertTokenFilter(tokenStream, STConvertType.simple2traditional,",",false);
+                        return new STConvertTokenFilter(tokenStream, STConvertType.SIMPLE_2_TRADITIONAL,",",false);
                     }
                 }));
 
@@ -130,7 +130,7 @@ public class STConvertIndicesAnalysis extends AbstractComponent {
 
                     @Override
                     public TokenStream create(TokenStream tokenStream) {
-                        return new STConvertTokenFilter(tokenStream, STConvertType.traditional2simple,",",false);
+                        return new STConvertTokenFilter(tokenStream, STConvertType.TRADITIONAL_2_SIMPLE,",",false);
                     }
                 }));
 
@@ -143,7 +143,7 @@ public class STConvertIndicesAnalysis extends AbstractComponent {
 
                     @Override
                     public TokenStream create(TokenStream tokenStream) {
-                        return new STConvertTokenFilter(tokenStream, STConvertType.simple2traditional,",",true);
+                        return new STConvertTokenFilter(tokenStream, STConvertType.SIMPLE_2_TRADITIONAL,",",true);
                     }
                 }));
 
@@ -156,7 +156,7 @@ public class STConvertIndicesAnalysis extends AbstractComponent {
 
                     @Override
                     public TokenStream create(TokenStream tokenStream) {
-                        return new STConvertTokenFilter(tokenStream, STConvertType.traditional2simple,",",true);
+                        return new STConvertTokenFilter(tokenStream, STConvertType.TRADITIONAL_2_SIMPLE,",",true);
                     }
                 }));
 
@@ -170,7 +170,7 @@ public class STConvertIndicesAnalysis extends AbstractComponent {
 
                     @Override
                     public Reader create(Reader tokenStream) {
-                        return new STConvertCharFilter(tokenStream,STConvertType.simple2traditional);
+                        return new STConvertCharFilter(tokenStream,STConvertType.SIMPLE_2_TRADITIONAL);
                     }
                 }));
         indicesAnalysisService.charFilterFactories().put("tsconvert",
@@ -182,7 +182,7 @@ public class STConvertIndicesAnalysis extends AbstractComponent {
 
                     @Override
                     public Reader create(Reader tokenStream) {
-                        return new STConvertCharFilter(tokenStream,STConvertType.traditional2simple);
+                        return new STConvertCharFilter(tokenStream,STConvertType.TRADITIONAL_2_SIMPLE);
                     }
                 }));
 

--- a/src/main/java/org/elasticsearch/index/analysis/STConvertAnalyzer.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertAnalyzer.java
@@ -38,9 +38,9 @@ public final class STConvertAnalyzer extends Analyzer {
 
     @Override
     protected TokenStreamComponents createComponents(String fieldName) {
-        STConvertType convertType= STConvertType.traditional2simple;
+        STConvertType convertType= STConvertType.TRADITIONAL_2_SIMPLE;
         if(type.equals("s2t")){
-            convertType = STConvertType.simple2traditional;
+            convertType = STConvertType.SIMPLE_2_TRADITIONAL;
         }
         return  new TokenStreamComponents(new STConvertTokenizer(convertType, delimiter,keepBoth));
     }

--- a/src/main/java/org/elasticsearch/index/analysis/STConvertCharFilter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertCharFilter.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
 
 public final class STConvertCharFilter extends BaseCharFilter {
 
-    private STConvertType convertType=STConvertType.traditional2simple;
+    private STConvertType convertType=STConvertType.TRADITIONAL_2_SIMPLE;
     private Reader transformedInput;
     public STConvertCharFilter(Reader in,STConvertType convertType) {
         super(in);

--- a/src/main/java/org/elasticsearch/index/analysis/STConvertTokenFilter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertTokenFilter.java
@@ -29,7 +29,7 @@ public class STConvertTokenFilter extends TokenFilter {
 
     private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
     private String delimiter=",";
-    private STConvertType convertType= STConvertType.simple2traditional;
+    private STConvertType convertType= STConvertType.SIMPLE_2_TRADITIONAL;
     private Boolean keepBoth=false;
     @Override
     public final boolean incrementToken() throws IOException {

--- a/src/main/java/org/elasticsearch/index/analysis/STConvertTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertTokenFilterFactory.java
@@ -37,9 +37,9 @@ public class STConvertTokenFilterFactory extends AbstractTokenFilterFactory {
     }
 
     @Override public TokenStream create(TokenStream tokenStream) {
-        STConvertType convertType= STConvertType.traditional2simple;
+        STConvertType convertType= STConvertType.TRADITIONAL_2_SIMPLE;
         if(type.equals("s2t")){
-            convertType = STConvertType.simple2traditional;
+            convertType = STConvertType.SIMPLE_2_TRADITIONAL;
         }
         return new STConvertTokenFilter(tokenStream,convertType,delimiter,keepBoth);
     }

--- a/src/main/java/org/elasticsearch/index/analysis/STConvertTokenizerFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertTokenizerFactory.java
@@ -42,9 +42,9 @@ public class STConvertTokenizerFactory extends AbstractTokenizerFactory {
 
     @Override
     public Tokenizer create() {
-        STConvertType convertType= STConvertType.traditional2simple;
+        STConvertType convertType= STConvertType.TRADITIONAL_2_SIMPLE;
         if(type.equals("s2t")){
-            convertType = STConvertType.simple2traditional;
+            convertType = STConvertType.SIMPLE_2_TRADITIONAL;
         }
 
         return new STConvertTokenizer(convertType, delimiter,keepBoth);

--- a/src/main/java/org/elasticsearch/index/analysis/STConvertType.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertType.java
@@ -1,6 +1,6 @@
 package org.elasticsearch.index.analysis;
 
 public enum STConvertType {
-    simple2traditional,
-    traditional2simple,
+    SIMPLE_2_TRADITIONAL,
+    TRADITIONAL_2_SIMPLE,
 }

--- a/src/main/java/org/elasticsearch/index/analysis/STConverter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConverter.java
@@ -82,7 +82,7 @@ public class STConverter {
 
     public String convert(STConvertType type,String in) {
            Map map=charMap;
-        if(type== STConvertType.simple2traditional){
+        if(type== STConvertType.SIMPLE_2_TRADITIONAL){
             map=revCharMap;
         }
 

--- a/src/test/java/org/elasticsearch/index/analysis/STConvertAnalysisTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/STConvertAnalysisTests.java
@@ -81,7 +81,7 @@ public class STConvertAnalysisTests {
     public void testTokenFilter() throws IOException {
         StringReader sr = new StringReader("刘德华");
         Analyzer analyzer = new StandardAnalyzer();
-        STConvertTokenFilter filter = new STConvertTokenFilter(analyzer.tokenStream("f", sr), STConvertType.simple2traditional, ",", true);
+        STConvertTokenFilter filter = new STConvertTokenFilter(analyzer.tokenStream("f", sr), STConvertType.SIMPLE_2_TRADITIONAL, ",", true);
         List<String> list = new ArrayList<String>();
         filter.reset();
         while (filter.incrementToken()) {
@@ -96,7 +96,7 @@ public class STConvertAnalysisTests {
 
         sr = new StringReader("刘德华");
         analyzer = new KeywordAnalyzer();
-        filter = new STConvertTokenFilter(analyzer.tokenStream("f", sr), STConvertType.simple2traditional, ",", false);
+        filter = new STConvertTokenFilter(analyzer.tokenStream("f", sr), STConvertType.SIMPLE_2_TRADITIONAL, ",", false);
         list.clear();
         filter.reset();
         while (filter.incrementToken()) {
@@ -117,7 +117,7 @@ public class STConvertAnalysisTests {
             System.out.println(value);
             StringReader sr = new StringReader(value);
 
-            STConvertTokenizer tokenizer = new STConvertTokenizer(STConvertType.traditional2simple, ",", true);
+            STConvertTokenizer tokenizer = new STConvertTokenizer(STConvertType.TRADITIONAL_2_SIMPLE, ",", true);
             tokenizer.setReader(sr);
             tokenizer.reset();
 

--- a/src/test/java/org/elasticsearch/index/analysis/STConverterTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/STConverterTest.java
@@ -12,8 +12,8 @@ public class STConverterTest extends TestCase {
     public void testConvert() throws Exception {
 
         STConverter stConverter=new STConverter();
-        String str= stConverter.convert(STConvertType.traditional2simple,"先禮後兵");
-        String str1= stConverter.convert(STConvertType.simple2traditional,"非诚勿扰");
+        String str= stConverter.convert(STConvertType.TRADITIONAL_2_SIMPLE,"先禮後兵");
+        String str1= stConverter.convert(STConvertType.SIMPLE_2_TRADITIONAL,"非诚勿扰");
         System.out.printf(str);
         System.out.println();
         System.out.printf(str1);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S00115  Constant names should comply with a naming convention

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S00115 

Please let me know if you have any questions.

Zeeshan Asghar