### PR TITLE
Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/STConvertAnalysisBinderProcessor.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertAnalysisBinderProcessor.java
@@ -35,6 +35,7 @@
 package org.elasticsearch.index.analysis;
 
 /**
+ * @deprecated
  */
 @Deprecated
 public class STConvertAnalysisBinderProcessor extends AnalysisModule.AnalysisBinderProcessor {

--- a/src/main/java/org/elasticsearch/index/analysis/STConvertAnalyzerProvider.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertAnalyzerProvider.java
@@ -22,6 +22,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.Index;
 
 /**
+ * @deprecated
  */
 @Deprecated
 public class STConvertAnalyzerProvider extends AbstractIndexAnalyzerProvider<STConvertAnalyzer> {

--- a/src/main/java/org/elasticsearch/index/analysis/STConvertTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertTokenFilterFactory.java
@@ -21,6 +21,9 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
+/**
+ * @deprecated
+ */
 @Deprecated
 public class STConvertTokenFilterFactory extends AbstractTokenFilterFactory {
     private String delimiter=",";

--- a/src/main/java/org/elasticsearch/index/analysis/STConvertTokenizerFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertTokenizerFactory.java
@@ -22,6 +22,10 @@ import org.elasticsearch.index.Index;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * @deprecated
+ */
 @Deprecated
 public class STConvertTokenizerFactory extends AbstractTokenizerFactory {
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck

Please let me know if you have any questions.

Zeeshan Asghar