### PR TITLE
General Code Improvement 2

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/STConvertTokenFilter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertTokenFilter.java
@@ -31,6 +31,14 @@ public class STConvertTokenFilter extends TokenFilter {
     private String delimiter=",";
     private STConvertType convertType= STConvertType.simple2traditional;
     private Boolean keepBoth=false;
+    
+    public STConvertTokenFilter(TokenStream in, STConvertType convertType,String delimiter,Boolean keepBoth) {
+        super(in);
+        this.delimiter = delimiter;
+        this.convertType = convertType;
+        this.keepBoth=keepBoth;
+    }
+    
     @Override
     public final boolean incrementToken() throws IOException {
 
@@ -61,14 +69,6 @@ public class STConvertTokenFilter extends TokenFilter {
         termAtt.setLength(stringBuilder.length());
         return true;
     }
-
-    public STConvertTokenFilter(TokenStream in, STConvertType convertType,String delimiter,Boolean keepBoth) {
-        super(in);
-        this.delimiter = delimiter;
-        this.convertType = convertType;
-        this.keepBoth=keepBoth;
-    }
-
 
     @Override
     public final void end() throws IOException {

--- a/src/main/java/org/elasticsearch/index/analysis/STConverter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConverter.java
@@ -11,7 +11,8 @@ public class STConverter {
     private Properties charMap = new Properties();
     private Properties revCharMap = new Properties();
     private Set conflictingSets  = new HashSet();
-
+    private static STConverter instance=new STConverter();
+    
     public STConverter(){
 
 
@@ -35,8 +36,7 @@ public class STConverter {
                 try {
                     if (reader != null)
                         reader.close();
-                    if (is != null)
-                        is.close();
+                    is.close();
                 } catch (IOException e) {
                 }
             }
@@ -92,7 +92,7 @@ public class STConverter {
         for (int i = 0; i < in.length(); i++) {
 
             char c = in.charAt(i);
-            String key = "" + c;
+            String key = Character.toString(c);
             source.append(key);
 
             if (conflictingSets.contains(source.toString())) {
@@ -111,8 +111,6 @@ public class STConverter {
         return target.toString();
     }
 
-    private static STConverter instance=new STConverter();
-
     public static STConverter getInstance(){
         if(instance==null){instance = new STConverter();}
         return instance;
@@ -129,7 +127,7 @@ public class STConverter {
                 stackString.setLength(0);
 
             } else {
-                outString.append("" + stackString.charAt(0));
+                outString.append(Character.toString( stackString.charAt(0)) );
                 stackString.delete(0, 1);
             }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1213  The members of an interface declaration or class should appear in a pre-defined order
findbugs:RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE Dodgy - Redundant nullcheck of value known to be non-null
squid:S2131  Primitives should not be boxed just for 'String' conversion

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/findbugs:RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.

Zeeshan Asghar