### PR TITLE
Use fresh index settings

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/STConvertTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertTokenFilterFactory.java
@@ -21,6 +21,8 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettingsService;
+
 /**
  * @deprecated
  */
@@ -29,8 +31,8 @@ public class STConvertTokenFilterFactory extends AbstractTokenFilterFactory {
     private String delimiter=",";
     private String type="t2s";
     private Boolean keepBoth=false;
-    @Inject public STConvertTokenFilterFactory(Index index, Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
-        super(index, indexSettings, name, settings);
+    @Inject public STConvertTokenFilterFactory(Index index, IndexSettingsService indexSettingsService, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettingsService.getSettings(), name, settings);
         type = settings.get("convert_type", "t2s");
         delimiter = settings.get("delimiter", ",");
         String keepBothStr = settings.get("keep_both", "false");

--- a/src/main/java/org/elasticsearch/index/analysis/STConvertTokenizerFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/STConvertTokenizerFactory.java
@@ -5,6 +5,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.settings.IndexSettingsService;
 
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -34,8 +35,8 @@ public class STConvertTokenizerFactory extends AbstractTokenizerFactory {
     private Boolean keepBoth=false;
 
     @Inject
-    public STConvertTokenizerFactory(Index index, @Assisted Settings indexSettings, @Assisted String name, @Assisted Settings settings) {
-        super(index, indexSettings, name, settings);
+    public STConvertTokenizerFactory(Index index, IndexSettingsService indexSettingsService, @Assisted String name, @Assisted Settings settings) {
+        super(index, indexSettingsService.getSettings(), name, settings);
          type = settings.get("convert_type", "t2s");
          delimiter = settings.get("delimiter", ",");
          String keepBothStr = settings.get("keep_both", "false");


### PR DESCRIPTION
This commit matches changes made to Elasticsearch for elastic/elasticsearch#14578

It corrects a bug which causes elasticsearch-analysis-stconvert to fail when a new token filter or tokenizer is defined rather than using those defined by the plugin, e.g.
```
"analysis" : {
    "filter" : {
        "s2t_convert": {
            "type": "stconvert",
            "delimiter": ",",
            "convert_type": "s2t"
        }
    },
    ...
}
```