### PR TITLE
Fix assembly to generate compliant zip file

### DIFF
--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -4,11 +4,12 @@
     <formats>
         <format>zip</format>
     </formats>
-    <includeBaseDirectory>false</includeBaseDirectory>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>elasticsearch</baseDirectory>
     <files>
         <file>
             <source>${project.basedir}/src/main/resources/plugin-descriptor.properties</source>
-            <outputDirectory></outputDirectory>
+            <outputDirectory>/</outputDirectory>
             <filtered>true</filtered>
         </file>
     </files>


### PR DESCRIPTION
Since elastic 5 plugins must be packaged in the elasticsearch base directory.