### PR TITLE
Upgrade to ES 9.1.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17, 21, 24]
+        java: [21, 24]
         elasticsearch: ['9.0.0', '9.0.7', '9.1.0', '9.1.4']
 
     steps:
@@ -30,9 +30,10 @@ jobs:
 
       - name: Set Elasticsearch ${{ matrix.elasticsearch }} in POM
         run: |
-          sed -i "s/<elasticsearch.version>.*<\/elasticsearch.version>/<elasticsearch.version>${{ matrix.elasticsearch }}<\/elasticsearch.version>/" pom.xml
+          sed -i "s/<elasticsearch.version>.*<\/elasticsearch.version>/<elasticsearch.version>${{ matrix.elasticsearch }}<\/elasticsearch.version>/" elasticsearch/pom.xml
           echo "Updated Elasticsearch version to ${{ matrix.elasticsearch }}"
-          grep -A 2 "<elasticsearch.version>" pom.xml
+          grep -A 2 "<elasticsearch.version>" elasticsearch/pom.xml
+
       - name: Build and test
         run: mvn verify -B
 
@@ -43,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17, 21, 24]
+        java: [21, 24]
         opensearch: ['2.0.1']
 
     steps:
@@ -59,8 +60,9 @@ jobs:
 
       - name: Set OpenSearch ${{ matrix.opensearch }} in POM
         run: |
-          sed -i "s/<opensearch.version>.*<\/opensearch.version>/<opensearch.version>${{ matrix.opensearch }}<\/opensearch.version>/" pom.xml
+          sed -i "s/<opensearch.version>.*<\/opensearch.version>/<opensearch.version>${{ matrix.opensearch }}<\/opensearch.version>/" opensearch/pom.xml
           echo "Updated OpenSearch version to ${{ matrix.opensearch }}"
-          grep -A 2 "<opensearch.version>" pom.xml
+          grep -A 2 "<opensearch.version>" opensearch/pom.xml
+
       - name: Build and test
         run: mvn verify -B

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17, 21, 24]
+        java: [21, 24]
         elasticsearch: ['9.0.0', '9.0.7', '9.1.0', '9.1.4']
 
     steps:
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17, 21, 24]
+        java: [21, 24]
         opensearch: ['2.0.1']
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,66 @@
+name: Test
+
+on:
+  push:
+    branches: ['*']
+  pull_request:
+    branches: ['*']
+
+jobs:
+  test-elasticsearch:
+    name: Test Elasticsearch=${{ matrix.elasticsearch }} JDK=${{ matrix.java }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [17, 21, 24]
+        elasticsearch: ['9.0.0', '9.0.7', '9.1.0', '9.1.4']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Set Elasticsearch ${{ matrix.elasticsearch }} in POM
+        run: |
+          sed -i "s/<elasticsearch.version>.*<\/elasticsearch.version>/<elasticsearch.version>${{ matrix.elasticsearch }}<\/elasticsearch.version>/" pom.xml
+          echo "Updated Elasticsearch version to ${{ matrix.elasticsearch }}"
+          grep -A 2 "<elasticsearch.version>" pom.xml
+      - name: Build and test
+        run: mvn verify -B
+
+  test-opensearch:
+    name: Test OpenSearch=${{ matrix.opensearch }} JDK=${{ matrix.java }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [17, 21, 24]
+        opensearch: ['2.0.1']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Set OpenSearch ${{ matrix.opensearch }} in POM
+        run: |
+          sed -i "s/<opensearch.version>.*<\/opensearch.version>/<opensearch.version>${{ matrix.opensearch }}<\/opensearch.version>/" pom.xml
+          echo "Updated OpenSearch version to ${{ matrix.opensearch }}"
+          grep -A 2 "<opensearch.version>" pom.xml
+      - name: Build and test
+        run: mvn verify -B

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ STConvert Analysis for Elasticsearch and OpenSearch
 ==================================
 
 ![](./assets/banner.png)
-
+[![Test](https://github.com/infinilabs/analysis-stconvert/actions/workflows/test.yml/badge.svg)](https://github.com/infinilabs/analysis-stconvert/actions/workflows/test.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.txt)
 
 STConvert is analyzer that convert Chinese characters between Traditional and Simplified. It supports major versions of Elasticsearch and OpenSearch. Maintained and supported with ❤️ by [INFINI Labs](https://infinilabs.com).
 
@@ -34,7 +35,7 @@ or you can use the `plugin` cli to install the plugin like this:
 For Elasticsearch
 
 ```
-bin/elasticsearch-plugin install https://get.infini.cloud/elasticsearch/analysis-stconvert/8.4.1
+bin/elasticsearch-plugin install https://get.infini.cloud/elasticsearch/analysis-stconvert/9.1.4
 ```
 
 For OpenSearch

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,8 +13,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,8 +13,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.17.1</version>
+			<version>2.19.0</version>
             <scope>provided</scope>
 		</dependency>
          <dependency>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -17,6 +17,8 @@
 
 
     <properties>
+        <elasticsearch.version>9.1.4</elasticsearch.version>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <elasticsearch.plugin.classname>com.infinilabs.stconvert.elasticsearch.AnalysisSTConvertPlugin</elasticsearch.plugin.classname>
         <elasticsearch.plugin.name>analysis-stconvert</elasticsearch.plugin.name>

--- a/opensearch/pom.xml
+++ b/opensearch/pom.xml
@@ -17,12 +17,13 @@
 
 
     <properties>
+        <opensearch.version>2.0.1</opensearch.version>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <opensearch.plugin.classname>com.infinilabs.stconvert.opensearch.AnalysisSTConvertPlugin</opensearch.plugin.classname>
         <opensearch.plugin.name>analysis-stconvert</opensearch.plugin.name>
         <opensearch.plugin.jvm>true</opensearch.plugin.jvm>
         <opensearch.assembly.descriptor>${project.basedir}/src/main/assemblies/plugin.xml</opensearch.assembly.descriptor>
-
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,6 @@
 
     <properties>
         <lucene.version>10.2.2</lucene.version>
-        <elasticsearch.version>9.1.4</elasticsearch.version>
-        <opensearch.version>2.0.1</opensearch.version>
         <maven.compiler.target>17</maven.compiler.target>
 
         <tests.rest.load_packaged>false</tests.rest.load_packaged>

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
     </developers>
 
     <properties>
-        <lucene.version>9.3.0</lucene.version>
-        <elasticsearch.version>9.0.0</elasticsearch.version>
+        <lucene.version>10.2.2</lucene.version>
+        <elasticsearch.version>9.1.4</elasticsearch.version>
         <opensearch.version>2.0.1</opensearch.version>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.target>17</maven.compiler.target>
 
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
         <skip.unit.tests>true</skip.unit.tests>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <lucene.version>10.2.2</lucene.version>
         <elasticsearch.version>9.1.4</elasticsearch.version>
         <opensearch.version>2.0.1</opensearch.version>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.target>21</maven.compiler.target>
 
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
         <skip.unit.tests>true</skip.unit.tests>


### PR DESCRIPTION
This PR does the following:
- Upgrade to Elasticsearch 9.1.4
- Adds Github Actions test workflow which covers both Elasticsearch and Opensearch on various versions.
- Updates the `pom.xml` files with updated/corrected dependencies.
- Adds Test and License badges to the README file.